### PR TITLE
Spring: Authentication and authorization

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -30,7 +30,11 @@
 			<artifactId>vaadin-spring-boot-starter</artifactId>
 			<version>23.0.4</version>
 		</dependency>
-
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.19.1</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>

--- a/app/src/main/java/pl/school/register/config/JWTConfig.java
+++ b/app/src/main/java/pl/school/register/config/JWTConfig.java
@@ -1,0 +1,38 @@
+package pl.school.register.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "jwt")
+public class JWTConfig {
+    private String secret;
+    private String prefix;
+    private int expiresAfterDays;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public int getExpiresAfterDays() {
+        return expiresAfterDays;
+    }
+
+    public void setExpiresAfterDays(int expiresAfterDays) {
+        this.expiresAfterDays = expiresAfterDays;
+    }
+}

--- a/app/src/main/java/pl/school/register/config/SecurityConfig.java
+++ b/app/src/main/java/pl/school/register/config/SecurityConfig.java
@@ -23,17 +23,19 @@ public class SecurityConfig {
     @Configuration
     class RESTSecurityConfig extends WebSecurityConfigurerAdapter{
 
-        private AccountDetailsService accountDetailsService;
-        private PasswordEncoder passwordEncoder;
+        private final AccountDetailsService accountDetailsService;
+        private final PasswordEncoder passwordEncoder;
+        private final JWTConfig jwtConfig;
 
-        public RESTSecurityConfig(AccountDetailsService accountDetailsService, PasswordEncoder passwordEncoder) {
+        public RESTSecurityConfig(AccountDetailsService accountDetailsService, PasswordEncoder passwordEncoder, JWTConfig jwtConfig) {
             this.accountDetailsService = accountDetailsService;
             this.passwordEncoder = passwordEncoder;
+            this.jwtConfig = jwtConfig;
         }
 
         @Override
         protected void configure(HttpSecurity http) throws Exception {
-            AuthenticationFilter filter = new AuthenticationFilter(authenticationManagerBean());
+            AuthenticationFilter filter = new AuthenticationFilter(authenticationManagerBean(), jwtConfig);
             filter.setFilterProcessesUrl("/api/account/login");
             http
                     .csrf().disable()
@@ -45,7 +47,7 @@ public class SecurityConfig {
                     .antMatchers("/api/student/**").hasAuthority("STUDENT")
                     .and()
                     .addFilter(filter)
-                    .addFilterBefore(new AuthorizationFilter(accountDetailsService), UsernamePasswordAuthenticationFilter.class);
+                    .addFilterBefore(new AuthorizationFilter(accountDetailsService, jwtConfig), UsernamePasswordAuthenticationFilter.class);
 
         }
 

--- a/app/src/main/java/pl/school/register/controller/ExampleController.java
+++ b/app/src/main/java/pl/school/register/controller/ExampleController.java
@@ -1,16 +1,35 @@
 package pl.school.register.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import pl.school.register.model.AccountInfo;
+import pl.school.register.service.AccountService;
+
+import java.security.Principal;
 
 @RestController()
 @RequestMapping(value = "/api")
 public class ExampleController {
 
+    final private AccountService accountService;
+    ExampleController(AccountService accountService){
+        this.accountService = accountService;
+    }
     @GetMapping(value = "/example")
     public String helloWorld(){
         return "Hello World!";
+    }
+
+    @GetMapping(value = "/student/info")
+    public ResponseEntity<AccountInfo> getCurrentStudentInfo(Authentication authentication){
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        AccountInfo accountInfo = accountService.getInfoByLogin(userDetails.getUsername());
+        return ResponseEntity.ok(accountInfo);
     }
 }

--- a/app/src/main/java/pl/school/register/controller/ExampleController.java
+++ b/app/src/main/java/pl/school/register/controller/ExampleController.java
@@ -17,7 +17,7 @@ import java.security.Principal;
 @RequestMapping(value = "/api")
 public class ExampleController {
 
-    final private AccountService accountService;
+    private final AccountService accountService;
     ExampleController(AccountService accountService){
         this.accountService = accountService;
     }

--- a/app/src/main/java/pl/school/register/filter/AuthenticationFilter.java
+++ b/app/src/main/java/pl/school/register/filter/AuthenticationFilter.java
@@ -3,12 +3,15 @@ package pl.school.register.filter;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import pl.school.register.config.JWTConfig;
 import pl.school.register.model.RequestAccount;
 
 import javax.servlet.FilterChain;
@@ -21,11 +24,14 @@ import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+@PropertySource("classpath:application.properties")
 public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
+    private final JWTConfig jwtConfig;
 
-    public AuthenticationFilter(AuthenticationManager authenticationManager) {
+    public AuthenticationFilter(AuthenticationManager authenticationManager, JWTConfig jwtConfig) {
         this.authenticationManager = authenticationManager;
+        this.jwtConfig = jwtConfig;
     }
 
     @Override
@@ -45,15 +51,15 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
         User user = (User) authResult.getPrincipal();
-        Algorithm algorithm = Algorithm.HMAC512("very_secure_secret".getBytes());
+        Algorithm algorithm = Algorithm.HMAC512(jwtConfig.getSecret().getBytes());
         String access_token = JWT.create()
                 .withSubject(user.getUsername())
-                .withExpiresAt(new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000))
+                .withExpiresAt(new Date(System.currentTimeMillis() + (long) (jwtConfig.getExpiresAfterDays()) * 24 * 60 * 60 * 1000))
                 .withIssuer(request.getRequestURL().toString())
                 .sign(algorithm);
         String refresh_token = JWT.create()
                 .withSubject(user.getUsername())
-                .withExpiresAt(new Date(System.currentTimeMillis() + 2 * 24 * 60 * 60 * 1000))
+                .withExpiresAt(new Date(System.currentTimeMillis() + (long) (jwtConfig.getExpiresAfterDays() + 1) * 24 * 60 * 60 * 1000))
                 .withIssuer(request.getRequestURL().toString())
                 .sign(algorithm);
 

--- a/app/src/main/java/pl/school/register/filter/AuthenticationFilter.java
+++ b/app/src/main/java/pl/school/register/filter/AuthenticationFilter.java
@@ -1,0 +1,66 @@
+package pl.school.register.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import pl.school.register.model.RequestAccount;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+
+    public AuthenticationFilter(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        if (request.getMethod().equals("POST")) {
+            try {
+                RequestAccount user = new ObjectMapper().readValue(request.getInputStream(), RequestAccount.class);
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword());
+                return authenticationManager.authenticate(authToken);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
+        User user = (User) authResult.getPrincipal();
+        Algorithm algorithm = Algorithm.HMAC512("very_secure_secret".getBytes());
+        String access_token = JWT.create()
+                .withSubject(user.getUsername())
+                .withExpiresAt(new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000))
+                .withIssuer(request.getRequestURL().toString())
+                .sign(algorithm);
+        String refresh_token = JWT.create()
+                .withSubject(user.getUsername())
+                .withExpiresAt(new Date(System.currentTimeMillis() + 2 * 24 * 60 * 60 * 1000))
+                .withIssuer(request.getRequestURL().toString())
+                .sign(algorithm);
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("access_token", access_token);
+        tokens.put("refresh_token", refresh_token);
+        response.setContentType(APPLICATION_JSON_VALUE);
+        new ObjectMapper().writeValue(response.getOutputStream(), tokens);
+    }
+}

--- a/app/src/main/java/pl/school/register/filter/AuthorizationFilter.java
+++ b/app/src/main/java/pl/school/register/filter/AuthorizationFilter.java
@@ -1,0 +1,65 @@
+package pl.school.register.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+import pl.school.register.service.AccountDetailsService;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class AuthorizationFilter extends OncePerRequestFilter {
+    final private AccountDetailsService accountDetailsService;
+    public AuthorizationFilter(AccountDetailsService accountDetailsService){
+        this.accountDetailsService = accountDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getServletPath().equals("/api/account/login")) {
+            filterChain.doFilter(request, response);
+        } else {
+            String authHeader = request.getHeader(AUTHORIZATION);
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                try {
+                    String token = authHeader.substring("Bearer ".length());
+                    Algorithm algorithm = Algorithm.HMAC512("very_secure_secret".getBytes());
+                    JWTVerifier verifier = JWT.require(algorithm).build();
+                    DecodedJWT decodedJWT = verifier.verify(token);
+                    String username = decodedJWT.getSubject();
+                    UserDetails userDetails = accountDetailsService.loadUserByUsername(username);
+                    UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                    filterChain.doFilter(request, response);
+                } catch (Exception e) {
+                    Map<String, String> error = new HashMap<>();
+                    response.setStatus(FORBIDDEN.value());
+                    error.put("error_message", e.getMessage());
+                    response.setContentType(APPLICATION_JSON_VALUE);
+                    new ObjectMapper().writeValue(response.getOutputStream(), error);
+                }
+            } else {
+                Map<String, String> error = new HashMap<>();
+                response.setStatus(FORBIDDEN.value());
+                error.put("error_message", "Forbidden Access");
+                response.setContentType(APPLICATION_JSON_VALUE);
+                new ObjectMapper().writeValue(response.getOutputStream(), error);
+            }
+        }
+    }
+}

--- a/app/src/main/java/pl/school/register/model/RequestAccount.java
+++ b/app/src/main/java/pl/school/register/model/RequestAccount.java
@@ -1,0 +1,4 @@
+package pl.school.register.model;
+
+public class RequestAccount extends Account{
+}

--- a/app/src/main/java/pl/school/register/repositories/AccountRepository.java
+++ b/app/src/main/java/pl/school/register/repositories/AccountRepository.java
@@ -11,5 +11,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     @Query(value = "SELECT role, first_name, last_name, login FROM account WHERE id = :id", nativeQuery = true)
     AccountInfo findAccountInfoById(@Param("id") Long id);
 
+    AccountInfo findAccountInfoByLogin(String login);
+
     Account findByLogin(String username);
 }

--- a/app/src/main/java/pl/school/register/service/AccountService.java
+++ b/app/src/main/java/pl/school/register/service/AccountService.java
@@ -33,4 +33,8 @@ public class AccountService {
     public AccountInfo getAccountInfo(Long id) {
         return accountRepository.findAccountInfoById(id);
     }
+
+    public AccountInfo getInfoByLogin(String login){
+        return accountRepository.findAccountInfoByLogin(login);
+    }
 }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.datasource.password=postgres
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create-drop
+jwt.secret=very_secure_change_it
+jwt.prefix=Bearer 
+jwt.expires-after-days=2


### PR DESCRIPTION
This PR adds Authentication and Authorization filters for Spring Security which are necessary for proper handling of `Account` roles. `secret`, `prefix` and `expireAfterDays` are inside `application.properties` and are then injected by `JWTConfig`.

To obtain JWT you need to send user credentials (login and password) to `[host]/api/login`

```sh
curl -X POST http://localhost:8080/api/account/login \
--data '{"login":"adas69PL", "password":"DzikiDzikus"}'
```

And on successful login it returns a pair of `access_token` and `refresh_token`.

In `ExampleController` I added an example endpoint `[host]/api/student/info` which requires authorization. Only `Account` with `Role` `STUDENT` has access to it.

A request to that endpoint would look like this:

```sh
curl http://localhost:8080/api/student/info -H "Authorization: Bearer TOKEN_OBTAINED_FROM_PREVIOUS_REQUEST"
```

As of now token refreshing is not implemented and I'm not sure if it will ever be so I might remove generating it in the future.

This PR doesn't break anything so I'm merging it as I need it for handling authorization in Vaadin.